### PR TITLE
harden docker implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM node:lts-alpine AS deps
 
 WORKDIR /opt/app
 COPY package.json pnpm-lock.yaml ./
+RUN npm install -g pnpm
 RUN pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed
@@ -15,13 +16,13 @@ FROM node:lts-alpine AS builder
 
 ENV NODE_ENV=production
 WORKDIR /opt/app
+RUN npm install -g pnpm
 COPY . .
 COPY --from=deps /opt/app/node_modules ./node_modules
 RUN pnpm build
 
 # Production image, copy all the files and run next
-FROM node:lts-alpine AS runner
-
+FROM gcr.io/distroless/nodejs18-debian11 AS runner
 ARG X_TAG
 WORKDIR /opt/app
 ENV NODE_ENV=production
@@ -31,4 +32,4 @@ COPY --from=builder /opt/app/.next ./.next
 COPY --from=builder /opt/app/node_modules ./node_modules
 ENV HOST=0.0.0.0
 ENV PORT=3000
-CMD ["node_modules/.bin/next", "start"]
+CMD ["./node_modules/next/dist/bin/next", "start"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -3,21 +3,45 @@
 version: '3'
 
 services:
-  frontend:
+  libremdb:
     container_name: libremdb
     build:
       context: .
-      network: host
+      dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    env_file: .env.local
+    env_file: .env.local.example
     depends_on:
-      - redis
+      - libremdb-redis
     restart: always
-  redis:
+    user: 65534:65534 # equivalent to the nobody user
+    read_only: true
+    tmpfs:
+      - /app/.next/cache/:size=10M,mode=0770,uid=65534,gid=65534,noexec,nosuid,nodev
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      - libremdb
+
+  libremdb-redis:
     container_name: libremdb_redis
     image: redis
     # FOR DEBUGGING ONLY
     # ports:
     #   - "6379:6379"
     restart: always
+    user: nobody
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /data:size=10M,mode=0770,uid=65534,gid=65534,noexec,nosuid,nodev
+    cap_drop:
+      - ALL
+    networks:
+      - libremdb
+
+networks:
+  libremdb:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -17,7 +17,7 @@ services:
     user: 65534:65534 # equivalent to the nobody user
     read_only: true
     tmpfs:
-      - /app/.next/cache/:size=10M,mode=0770,uid=65534,gid=65534,noexec,nosuid,nodev
+      - /opt/app/.next/cache/:size=10M,mode=0770,uid=65534,gid=65534,noexec,nosuid,nodev
     security_opt:
       - no-new-privileges:true
     cap_drop:


### PR DESCRIPTION
This PR hardens both the Dockerfile and the docker-compose file.

Dockerfile: switched to a distroless image.

Docker Compose (renamed to docker-compose.yml): 
* `user`: this is set to the UID:GID of `nobody`, the least privileged account.
* `read_only`: this is set to true, this container doesn't write anything to the filesystem.
* `security_opt`: there's a lot of settings, but the important on is that the container doesn't get any privileges when asking for them.
* `cap_drop`: this drops all capabilities like CHOWN, SETUID, etc.
* `tmpfs`: this is essentially a volume in RAM. it gets wiped every container restart.
* `networks`: this puts `libremdb` in its own separate bridge network where it cannot talk to other containers.

