### PR TITLE
add libremdb.cmc.pub

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Inspired by projects like [teddit](https://codeberg.org/teddit/teddit), [nitter]
 | <https://imdb.nerdvpn.de/>               | No                                                                                     | No                                                                          | UA      | No         | Operated by [Weidenwiesel](https://nerdvpn.de/)                    |
 | <https://libremdb.canine.tools/>         | No                                                                                     | No                                                                          | US      | No         | Operated by [canine.tools](https://canine.tools/)                  |
 | <https://libremdb-fly.fly.dev/>          | No                                                                                     | No                                                                          | US      | No         | Operated by [jodanjodan](https://github.com/JodanJodan)                  |
+| <https://libremdb.cmc.pub/>              | No                                                                                     | No                                                                          | US      | No         | Operated by [cmc](https://cmc.pub)                  |
 
 Instances list in JSON format can be found in [instances.json](instances.json) file.
 

--- a/instances.json
+++ b/instances.json
@@ -125,5 +125,9 @@
     "clearnet": "https://libremdb-fly.fly.dev/",
     "cdn": false,
     "country": "US"
-  }
+  },
+  {
+    "clearnet": "https://cmc.pub/",
+    "cdn": false,
+    "country": "US"
 ]


### PR DESCRIPTION
Adding [libremdb.cmc.pub](https://libremdb.cmc.pub/) as an instance.

Please let me know if I need to flip the Cloudflare to yes. DNS runs through Cloudflare but proxying is NOT enabled, so it doesn't use Cloudflare's proxy network.