### PR TITLE
feat: redirect paths from specific languages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,11 @@ const nextConfig = {
         destination: '/find',
         permanent: true,
       },
+      {
+        source: '/:langcode(\\w{2})/:slug*',
+        destination: '/:slug*',
+        permanent: true,
+      },
     ];
   },
   images: {


### PR DESCRIPTION
Hey,

first of all thanks for all the efforts spent on this awesome project!

I've noticed that some search engines return language specific imdb results, e.g. `https://www.imdb.com/fr/title/tt9603208`. At the moment LibreMDB returns a 404 error now, even though the page is supported (just not in the right language).

Therefore, this PR redirects all routes of the pattern `/{two language code characters}/{full path}` to `/{full path}`. I made the assumption that there are no other routes that conflict with the pattern as all other routes have a length of 3 or more characters, I hope that's fine. It's possible to add exceptions in case of conflicts, i.e. `'/:langcode((?!route-that-we-dont-want-to-redirect)\\w{2})/:slug*'`.

Cheers