### PR TITLE
Add EXPOSE instruction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ COPY --from=builder /opt/app/.next ./.next
 COPY --from=builder /opt/app/node_modules ./node_modules
 ENV HOST=0.0.0.0
 ENV PORT=3000
+EXPOSE 3000
 CMD ["./node_modules/next/dist/bin/next", "start"]


### PR DESCRIPTION
This PR adds an `EXPOSE` instruction to inform Docker that the container listens on the specified network port at runtime.

https://docs.docker.com/reference/dockerfile/#expose