### PR TITLE
feat(title): adds originalTitle

### DIFF
--- a/src/components/card/CardBasic.tsx
+++ b/src/components/card/CardBasic.tsx
@@ -9,9 +9,10 @@ type Props = {
   className?: string;
   image?: string;
   title: string;
+  originalTitle?: string;
 } & ComponentPropsWithoutRef<'section'>;
 
-const CardBasic = ({ image, children, className, title, ...rest }: Props) => {
+const CardBasic = ({ image, children, className, title, originalTitle, ...rest }: Props) => {
   const style: CSSProperties = {
     backgroundImage: image && `url(${getProxiedIMDbImgUrl(modifyIMDbImg(image, 300))})`,
   };
@@ -36,6 +37,7 @@ const CardBasic = ({ image, children, className, title, ...rest }: Props) => {
       </div>
       <div className={styles.info}>
         <h1 className={`${styles.title} heading heading__primary`}>{title}</h1>
+        {originalTitle && <span className={styles.originalTitle}>{originalTitle}</span>}
         {children}
       </div>
     </Card>

--- a/src/components/title/Basic.tsx
+++ b/src/components/title/Basic.tsx
@@ -22,6 +22,7 @@ const Basic = ({ data, className }: Props) => {
       className={`${styles.container} ${className}`}
       image={data.poster?.url}
       title={data.title}
+      originalTitle={data.originalTitle}
     >
       <ul className={styles.meta} aria-label='quick facts'>
         {data.status && data.status.id !== 'released' && (

--- a/src/styles/modules/components/card/card-basic.module.scss
+++ b/src/styles/modules/components/card/card-basic.module.scss
@@ -95,3 +95,7 @@
     text-align: center;
   }
 }
+
+.originalTitle {
+  font-style: italic;
+}

--- a/src/utils/cleaners/title.ts
+++ b/src/utils/cleaners/title.ts
@@ -14,10 +14,10 @@ const cleanTitle = (rawData: RawTitle) => {
       id: main.id,
       isAdult: main.isAdult,
       title: main.titleText.text,
-      // ...(main.originalTitleText.text.toLowerCase() !==
-      //   main.titleText.text.toLowerCase() && {
-      //   originalTitle: main.originalTitleText.text,
-      // }),
+      ...(main.originalTitleText.text.toLowerCase() !==
+        main.titleText.text.toLowerCase() && {
+        originalTitle: main.originalTitleText.text,
+      }),
       type: {
         id: main.titleType.id as 'movie' | 'tvSeries' | 'tvEpisode' | 'videoGame',
         name: main.titleType.text,


### PR DESCRIPTION
Adds originalTitle to CardBasic for titles that are in a different language than the original
If the title and originalTitle are the same, don't show it.

I did basic formatting; feel free to change it or suggest changes.

Fixes #88 (in a way)

Accessing in Germany
<img width="750" height="388" alt="CleanShot 2025-08-08 at 18 23 40" src="https://github.com/user-attachments/assets/212d3067-197d-4939-939a-9ec23db32ce8" />
Accessing in Brazil
<img width="753" height="337" alt="CleanShot 2025-08-08 at 18 24 14" src="https://github.com/user-attachments/assets/4082f201-343b-4b23-b446-06a2e0ee48ac" />
