### PR TITLE
fix(title): center originalTitle in mobile

### DIFF
--- a/src/styles/modules/components/card/card-basic.module.scss
+++ b/src/styles/modules/components/card/card-basic.module.scss
@@ -98,4 +98,8 @@
 
 .originalTitle {
   font-style: italic;
+
+  @include helper.bp('bp-900') {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
In #105 the `originalTitle` was added, but on mobile the text was aligned to the left, while the rest of the content was centered. This PR fixes this, applying the same media query rule as the `title`.